### PR TITLE
Support RWKV World Vocab/Tokenizer.

### DIFF
--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -93,6 +93,7 @@ def get_args():
             "GPT2BPETokenizer",
             "CharLevelTokenizer",
             "TiktokenTokenizer",
+            "RWKVWorld"
         ],
         help="What type of tokenizer to use.",
     )

--- a/tools/tokenizer.py
+++ b/tools/tokenizer.py
@@ -38,6 +38,9 @@ def build_tokenizer(args):
     if args.tokenizer_type.lower() == "HFTokenizer".lower():
         assert args.vocab_file is not None
         tokenizer = HFTokenizer(args.vocab_file)
+    elif args.tokenizer_type.lower() == "RWKVWorld".lower():
+        assert args.vocab_file is not None
+        tokenizer = RWKVTokenizer(args)
     else:
         raise NotImplementedError(
             "{} tokenizer is not " "implemented.".format(args.tokenizer_type)
@@ -166,3 +169,26 @@ class HFTokenizer(AbstractTokenizer):
     def eod(self):
         return self.eod_id
 
+class RWKVTokenizer(AbstractTokenizer):
+    def __init__(self, args):
+        name = "RWKVTokenizer"
+        super().__init__(name)
+        
+        from rwkv.utils import PIPELINE
+        self.tokenizer = PIPELINE(None, args.vocab_file)
+    @property
+    def eod(self):
+        return 0
+    def tokenize(self, text: str):
+        return self.tokenizer.encode(text)
+    
+    @property
+    def inv_vocab(self):
+        raise NotImplementedError()
+    @property
+    def vocab(self):
+        raise NotImplementedError()
+    @property
+    def vocab_size(self):
+        # return 65536
+        return len(self.tokenizer.tokenizer.idx2token)


### PR DESCRIPTION
*More things should be done!*
In tools/indexed_dataset.py :: __best_fitting_dtype. Makes the output binidx file dtype int32. And later RWKV-Train encounters error for int32 datas.
I think should allow <= 65536 vocab size to use uint16 for output, instead of only < 65500.